### PR TITLE
Implement Stable ABI wheels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -38,18 +38,14 @@ jobs:
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e  # v3.3.1
         env:
           CIBW_SKIP: "*-musllinux*"
-          # We'll need this only if we go for ABI3
-          # CIBW_BUILD: "cp311-* cp314-*"
+          CIBW_BUILD: "cp311-* cp314-*"
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD_FRONTEND: build
-          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_REQUIRES: pytest abi3audit
           CIBW_TEST_COMMAND: >
             python -c "import geometry_utils; print(f'geometry_utils v{geometry_utils.__version__}')" &&
             python -m pytest --pyargs geometry_utils
-        # with:
-        #   package-dir: .
-        #   output-dir: wheelhouse
-        #   config-file: "{package}/pyproject.toml"
+            abi3audit ${{ github.workspace }}/wheelhouse/*.whl --summary --assume-minimum-abi3 --verbose --strict
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -45,7 +45,7 @@ jobs:
           CIBW_TEST_COMMAND: >
             python -c "import geometry_utils; print(f'geometry_utils v{geometry_utils.__version__}')" &&
             python -m pytest --pyargs geometry_utils &&
-            abi3audit ${{ github.workspace }}/wheelhouse/*.whl --summary --assume-minimum-abi3 --verbose --strict
+            abi3audit ${{ github.workspace }}/wheelhouse/*.whl --summary --assume-minimum-abi3 3.11 --verbose --strict
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -44,7 +44,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest abi3audit
           CIBW_TEST_COMMAND: >
             python -c "import geometry_utils; print(f'geometry_utils v{geometry_utils.__version__}')" &&
-            python -m pytest --pyargs geometry_utils
+            python -m pytest --pyargs geometry_utils &&
             abi3audit ${{ github.workspace }}/wheelhouse/*.whl --summary --assume-minimum-abi3 --verbose --strict
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  release:
+    types:
+      - published
 
 jobs:
   build_wheels:
@@ -8,36 +13,59 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # macos-latest is apple silicon
+      # no windows-11-arm -- 'cause there isn't a numpy wheel for it
       matrix:
-        # macos-latest is apple silicon
-        # no windows-11-arm -- 'cause there isn't a numpy wheel for it
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-15-intel]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+          - os: windows-latest
+            arch: AMD64
+          - os: macos-latest
+            arch: arm64
+          - os: macos-15-intel
+            arch: x86_64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
-        # env:
-        #   CIBW_SOME_OPTION: value
-        #   ...
+      - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
+        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e  # v3.3.1
+        env:
+          CIBW_SKIP: "*-musllinux*"
+          # We'll need this only if we go for ABI3
+          # CIBW_BUILD: "cp311-* cp314-*"
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD_FRONTEND: build
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: >
+            python -c "import geometry_utils; print(f'geometry_utils v{geometry_utils.__version__}')" &&
+            python -m pytest --pyargs geometry_utils
         # with:
         #   package-dir: .
         #   output-dir: wheelhouse
         #   config-file: "{package}/pyproject.toml"
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: ${{ github.workspace }}/wheelhouse/*.whl
+    permissions:
+      actions: write
 
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         fetch-depth: 0  # Optional, use if you use setuptools_scm
+        persist-credentials: false
 
     - name: Build SDist
       run: pipx run build --sdist
@@ -51,21 +79,21 @@ jobs:
       url: https://pypi.org/project/geometry-utils/
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: success() && github.event_name == 'release'
 
     steps:
     - name: get wheels from artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
       with:
         pattern: cibw-*
-        path: dist
+        path: ${{ github.workspace }}/dist
         merge-multiple: true
 
 # got this from https://github.com/pypa/gh-action-pypi-publish
     # - name: Publish package distributions to PyPI
     #   uses: pypa/gh-action-pypi-publish@release/v1
     - name: Publish package distributions to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
       with:
         repository-url: https://test.pypi.org/legacy/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,27 +6,38 @@ option(BUILD_DEPS OFF)
 find_package(
   Python
   COMPONENTS Interpreter Development.Module NumPy
-  REQUIRED)
+  REQUIRED
+  ${SKBUILD_SABI_COMPONENT}
+)
 
 include(UseCython)
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+if (NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
+  if ("${SKBUILD_SABI_VERSION}" VERSION_LESS "3.11")
+    message(FATAL_ERROR "ABI3 requires python>=3.11")
+  endif()
+  set(USE_SABI USE_SABI ${SKBUILD_SABI_VERSION})
+endif()
+
 cython_transpile(src/cy_src/cy_polygons.pyx LANGUAGE C OUTPUT_VARIABLE cy_polygons_c)
 python_add_library(cy_polygons
                    MODULE "${cy_polygons_c}"
                    src/cy_src/c_point_in_polygon.c
-                   WITH_SOABI)
+                   WITH_SOABI
+                   ${USE_SABI}
+                  )
 target_link_libraries(cy_polygons PUBLIC Python::NumPy)
 install(TARGETS cy_polygons DESTINATION geometry_utils)
 
 cython_transpile(src/cy_src/cy_line_crossings.pyx LANGUAGE C OUTPUT_VARIABLE cy_line_crossings_c)
-python_add_library(cy_line_crossings MODULE "${cy_line_crossings_c}" WITH_SOABI)
+python_add_library(cy_line_crossings MODULE "${cy_line_crossings_c}" WITH_SOABI ${USE_SABI})
 target_link_libraries(cy_line_crossings PUBLIC Python::NumPy)
 install(TARGETS cy_line_crossings DESTINATION geometry_utils)
 
 cython_transpile(src/cy_src/cy_rect.pyx LANGUAGE C OUTPUT_VARIABLE cy_rect_c)
-python_add_library(cy_rect MODULE "${cy_rect_c}" WITH_SOABI)
+python_add_library(cy_rect MODULE "${cy_rect_c}" WITH_SOABI ${USE_SABI})
 target_link_libraries(cy_rect PUBLIC Python::NumPy)
 install(TARGETS cy_rect DESTINATION geometry_utils)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [{ include-group = "test" }, { include-group = "build"}, "build"]
 
 [tool.scikit-build]
 build-dir = "build"
+wheel.py-api = "cp311"
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "cython", "numpy", "cython-cmake"]
+requires = ["scikit-build-core", "cython", "numpy>=2", "cython-cmake"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -8,7 +8,7 @@ description = "Utilities for basic computational geometry directly with numpy ar
 authors = [{name = "Chris Barker", email = "Chris.Barker@noaa.gov"}]
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">= 3.10"
+requires-python = ">=3.11"
 dependencies = ["numpy"]
 dynamic = ["version"]
 classifiers = [
@@ -17,10 +17,10 @@ classifiers = [
   # Indicate who your project is intended for
   "Intended Audience :: Developers",
 
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]


### PR DESCRIPTION
@ChrisBarker-NOAA in this PR:

- made some minor fixes to get the files and run on releases (published)
- used hashes instead of releases for security reasons, and added a recommended cooldown period for GHA updates


Should we do #10 in this PR too? Or maybe a fresh one after this to avoid big changes in a single merge.

Hopefully I did not break anything!